### PR TITLE
Bugfix: scantailor-cli doesnt honor color-mode settings from projectfile...

### DIFF
--- a/CommandLine.cpp
+++ b/CommandLine.cpp
@@ -38,7 +38,6 @@
 #include "Margins.h"
 #include "Despeckle.h"
 
-
 CommandLine CommandLine::m_globalInstance;
 
 
@@ -292,12 +291,14 @@ CommandLine::fetchDpi(QString oname)
 output::ColorParams::ColorMode
 CommandLine::fetchColorMode()
 {
-	QString cm = m_options["color-mode"].toLower();
-	
-	if (cm == "color_grayscale")
-		return output::ColorParams::COLOR_GRAYSCALE;
-	else if (cm == "mixed")
-		return output::ColorParams::MIXED;
+    if (m_options.contains("color-mode")) {
+        QString cm = m_options["color-mode"].toLower();
+
+        if (cm == "color_grayscale")
+            return output::ColorParams::COLOR_GRAYSCALE;
+        else if (cm == "mixed")
+            return output::ColorParams::MIXED;
+    }
 
 	return output::ColorParams::BLACK_AND_WHITE;
 }


### PR DESCRIPTION
.... It alwas convertes pictures to black and white instead of color

Found when using DIYBookscanner/spreads when manually editing via gui and letting spreads continue running scantailor-cli --start-filter=6 /tmp/spreads.TaZcoK/tmpuNi7DS-0.ScanTailor /tmp/st-outEvBCSO
