### PR TITLE
Don't normalize mixed mode pictures

### DIFF
--- a/filters/output/OutputGenerator.cpp
+++ b/filters/output/OutputGenerator.cpp
@@ -580,7 +580,7 @@ OutputGenerator::processWithoutDewarping(
 	QPolygonF normalize_illumination_crop_area(m_xform.resultingPreCropArea());
 	normalize_illumination_crop_area.translate(-normalize_illumination_rect.topLeft());
 
-	if (render_params.normalizeIllumination()) {
+	if (render_params.normalizeIllumination() && !render_params.mixedOutput()) {
 		maybe_normalized = normalizeIlluminationGray(
 			status, input.grayImage(), orig_image_crop_area,
 			m_xform.transform(), normalize_illumination_rect, 0, dbg
@@ -686,7 +686,8 @@ OutputGenerator::processWithoutDewarping(
 	}
 	
 	if (render_params.normalizeIllumination()
-			&& !input.origImage().allGray()) {
+			&& !input.origImage().allGray()
+			&& !render_params.mixedOutput()) {
 		assert(maybe_normalized.format() == QImage::Format_Indexed8);
 		QImage tmp(
 			transform(


### PR DESCRIPTION
In non-dewarped mixed mode, avoid equalizing illumination in pictures.  I'm not sure enough of how dewarped mode is handled (around line 877) to touch that one.

Note that this is a "this works for me" quick fix; you may wish to handle it differently (for example like in the much more elaborate "featured" branch).