### PR TITLE
Fix build with boost 1.60

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -1898,8 +1898,8 @@ MainWindow::showInsertFileDialog(BeforeOrAfter before_or_after, ImageId const& e
 		ImageFileInfo image_file_info(file_info, std::vector<ImageMetadata>());
 
 		ImageMetadataLoader::Status const status = ImageMetadataLoader::load(
-			files.at(i), bind(&std::vector<ImageMetadata>::push_back,
-			boost::ref(image_file_info.imageInfo()), _1)
+			files.at(i), boost::lambda::bind(&std::vector<ImageMetadata>::push_back,
+			boost::ref(image_file_info.imageInfo()), boost::lambda::_1)
 		);
 
 		if (status == ImageMetadataLoader::LOADED) {
@@ -1921,7 +1921,7 @@ MainWindow::showInsertFileDialog(BeforeOrAfter before_or_after, ImageId const& e
 	}
 
 	// Check if there is at least one DPI that's not OK.
-	if (std::find_if(new_files.begin(), new_files.end(), !bind(&ImageFileInfo::isDpiOK, _1)) != new_files.end()) {
+	if (std::find_if(new_files.begin(), new_files.end(), !boost::lambda::bind(&ImageFileInfo::isDpiOK, boost::lambda::_1)) != new_files.end()) {
 
 		std::auto_ptr<FixDpiDialog> dpi_dialog(new FixDpiDialog(new_files, this));
 		dpi_dialog->setWindowModality(Qt::WindowModal);

--- a/ThumbnailSequence.cpp
+++ b/ThumbnailSequence.cpp
@@ -491,7 +491,7 @@ ThumbnailSequence::Impl::Impl(
 	m_pSelectionLeader(0)
 {
 	m_graphicsScene.setContextMenuEventCallback(
-		bind(&Impl::sceneContextMenuEvent, this, _1)
+		boost::lambda::bind(&Impl::sceneContextMenuEvent, this, boost::lambda::_1)
 	);
 }
 
@@ -605,7 +605,7 @@ ThumbnailSequence::Impl::invalidateThumbnail(PageInfo const& page_info)
 {
 	ItemsById::iterator const id_it(m_itemsById.find(page_info.id()));
 	if (id_it != m_itemsById.end()) {
-		m_itemsById.modify(id_it, bind(&Item::pageInfo, _1) = page_info);
+		m_itemsById.modify(id_it, boost::lambda::bind(&Item::pageInfo, boost::lambda::_1) = page_info);
 		invalidateThumbnailImpl(id_it);
 	}
 }
@@ -725,10 +725,10 @@ ThumbnailSequence::Impl::invalidateAllThumbnails()
 	// Sort pages in m_itemsInOrder using m_ptrOrderProvider.
 	if (m_ptrOrderProvider.get()) {
 		m_itemsInOrder.sort(
-			bind(
+			boost::lambda::bind(
 				&PageOrderProvider::precedes, m_ptrOrderProvider.get(),
-				bind(&Item::pageId, _1), bind(&Item::incompleteThumbnail, _1),
-				bind(&Item::pageId, _2), bind(&Item::incompleteThumbnail, _2) 
+				boost::lambda::bind(&Item::pageId, boost::lambda::_1), bind(&Item::incompleteThumbnail, boost::lambda::_1),
+				boost::lambda::bind(&Item::pageId, boost::lambda::_2), bind(&Item::incompleteThumbnail, boost::lambda::_2)
 			)
 		);
 	}

--- a/filters/deskew/Filter.cpp
+++ b/filters/deskew/Filter.cpp
@@ -85,9 +85,9 @@ Filter::saveSettings(ProjectWriter const& writer, QDomDocument& doc) const
 	
 	QDomElement filter_el(doc.createElement("deskew"));
 	writer.enumPages(
-		bind(
+		boost::lambda::bind(
 			&Filter::writePageSettings,
-			this, boost::ref(doc), var(filter_el), _1, _2
+			this, boost::ref(doc), var(filter_el), boost::lambda::_1, boost::lambda::_2
 		)
 	);
 	

--- a/filters/fix_orientation/Filter.cpp
+++ b/filters/fix_orientation/Filter.cpp
@@ -100,9 +100,9 @@ Filter::saveSettings(
 	
 	QDomElement filter_el(doc.createElement("fix-orientation"));
 	writer.enumImages(
-		bind(
+		boost::lambda::bind(
 			&Filter::writeImageSettings,
-			this, boost::ref(doc), var(filter_el), _1, _2
+			this, boost::ref(doc), var(filter_el), boost::lambda::_1, boost::lambda::_2
 		)
 	);
 	

--- a/filters/output/Filter.cpp
+++ b/filters/output/Filter.cpp
@@ -91,9 +91,9 @@ Filter::saveSettings(
 	
 	QDomElement filter_el(doc.createElement("output"));
 	writer.enumPages(
-		bind(
+		boost::lambda::bind(
 			&Filter::writePageSettings,
-			this, boost::ref(doc), var(filter_el), _1, _2
+			this, boost::ref(doc), var(filter_el), boost::lambda::_1, boost::lambda::_2
 		)
 	);
 	

--- a/filters/page_layout/Filter.cpp
+++ b/filters/page_layout/Filter.cpp
@@ -136,9 +136,9 @@ Filter::saveSettings(
 	
 	QDomElement filter_el(doc.createElement("page-layout"));
 	writer.enumPages(
-		bind(
+		boost::lambda::bind(
 			&Filter::writePageSettings,
-			this, boost::ref(doc), var(filter_el), _1, _2
+			this, boost::ref(doc), var(filter_el), boost::lambda::_1, boost::lambda::_2
 		)
 	);
 	

--- a/filters/page_split/Filter.cpp
+++ b/filters/page_split/Filter.cpp
@@ -110,9 +110,9 @@ Filter::saveSettings(
 	);
 	
 	writer.enumImages(
-		bind(
+		boost::lambda::bind(
 			&Filter::writeImageSettings,
-			this, boost::ref(doc), var(filter_el), _1, _2
+			this, boost::ref(doc), var(filter_el), boost::lambda::_1, boost::lambda::_2
 		)
 	);
 	

--- a/filters/select_content/Filter.cpp
+++ b/filters/select_content/Filter.cpp
@@ -119,9 +119,9 @@ Filter::saveSettings(
 	
 	QDomElement filter_el(doc.createElement("select-content"));
 	writer.enumPages(
-		bind(
+		boost::lambda::bind(
 			&Filter::writePageSettings,
-			this, boost::ref(doc), var(filter_el), _1, _2
+			this, boost::ref(doc), var(filter_el), boost::lambda::_1, boost::lambda::_2
 		)
 	);
 	


### PR DESCRIPTION
Always use fully qualified boost::lambda::{bind,_1,_2}

With boost 1.60 there's a namespace conflict between boost::bind and boost::lambda::bind and placeholders are no longer in global namespace, so use fully qualified names for these.

It is advised to switch away from "using namespace" statements completely.