### PR TITLE
Fix compilation with GCC 6

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -1897,8 +1897,10 @@ MainWindow::showInsertFileDialog(BeforeOrAfter before_or_after, ImageId const& e
 		QFileInfo const file_info(files[i]);
 		ImageFileInfo image_file_info(file_info, std::vector<ImageMetadata>());
 
+		void (std::vector<ImageMetadata>::*push_back) (const ImageMetadata&) =
+			&std::vector<ImageMetadata>::push_back;
 		ImageMetadataLoader::Status const status = ImageMetadataLoader::load(
-			files.at(i), boost::lambda::bind(&std::vector<ImageMetadata>::push_back,
+			files.at(i), boost::lambda::bind(push_back,
 			boost::ref(image_file_info.imageInfo()), boost::lambda::_1)
 		);
 

--- a/filters/page_split/PageLayoutEstimator.cpp
+++ b/filters/page_split/PageLayoutEstimator.cpp
@@ -523,7 +523,8 @@ PageLayoutEstimator::cutAtWhitespaceDeskewed150(
 	
 	std::deque<Span> spans;
 	SlicedHistogram hist(cc_img, SlicedHistogram::COLS);
-	span_finder.find(hist, bind(&std::deque<Span>::push_back, var(spans), _1));
+	void (std::deque<Span>::*push_back) (const Span&) = &std::deque<Span>::push_back;
+	span_finder.find(hist, boost::lambda::bind(push_back, var(spans), _1));
 	
 	if (dbg) {
 		visualizeSpans(*dbg, spans, input, "spans");

--- a/tests/TestContentSpanFinder.cpp
+++ b/tests/TestContentSpanFinder.cpp
@@ -37,9 +37,11 @@ BOOST_AUTO_TEST_CASE(test_empty_input)
 	ContentSpanFinder span_finder;
 	
 	std::vector<Span> spans;
+	void (std::vector<Span>::*push_back) (const Span&) =
+		&std::vector<Span>::push_back;
 	span_finder.find(
 		SlicedHistogram(),
-		bind(&std::vector<Span>::push_back, var(spans), _1)
+		boost::lambda::bind(push_back, var(spans), _1)
 	);
 	
 	BOOST_CHECK(spans.empty());
@@ -63,7 +65,9 @@ BOOST_AUTO_TEST_CASE(test_min_content_width)
 	span_finder.setMinContentWidth(2);
 	
 	std::vector<Span> spans;
-	span_finder.find(hist, bind(&std::vector<Span>::push_back, var(spans), _1));
+	void (std::vector<Span>::*push_back) (const Span&) =
+		&std::vector<Span>::push_back;
+	span_finder.find(hist, boost::lambda::bind(push_back, var(spans), _1));
 	
 	BOOST_REQUIRE(spans.size() == 2);
 	BOOST_REQUIRE(spans[0] == Span(3, 3+3));
@@ -88,7 +92,9 @@ BOOST_AUTO_TEST_CASE(test_min_whitespace_width)
 	span_finder.setMinWhitespaceWidth(2);
 	
 	std::vector<Span> spans;
-	span_finder.find(hist, bind(&std::vector<Span>::push_back, var(spans), _1));
+	void (std::vector<Span>::*push_back) (const Span&) =
+		&std::vector<Span>::push_back;
+	span_finder.find(hist, boost::lambda::bind(push_back, var(spans), _1));
 	
 	BOOST_REQUIRE(spans.size() == 2);
 	BOOST_REQUIRE(spans[0] == Span(1, 1+4));
@@ -114,7 +120,9 @@ BOOST_AUTO_TEST_CASE(test_min_content_and_whitespace_width)
 	span_finder.setMinWhitespaceWidth(2);
 	
 	std::vector<Span> spans;
-	span_finder.find(hist, bind(&std::vector<Span>::push_back, var(spans), _1));
+	void (std::vector<Span>::*push_back) (const Span&) =
+		&std::vector<Span>::push_back;
+	span_finder.find(hist, boost::lambda::bind(push_back, var(spans), _1));
 	
 	// Note that although a content block at index 1 is too short,
 	// it's still allowed to merge with content at positions 3 and 4


### PR DESCRIPTION
GCC 6 defaults to a newer C++ standard version.  C++11 introduced a new overload for push_back so it is now sometimes necessary to specify which overload is required.  C++11 also introduced std::bind so we need to specify the namespace when using boost::lambda::bind.