### PR TITLE
basic multithread support added

### DIFF
--- a/MainWindow.h
+++ b/MainWindow.h
@@ -44,6 +44,7 @@
 #include <memory>
 #include <vector>
 #include <set>
+#include <QList>
 
 class AbstractFilter;
 class AbstractRelinker;
@@ -170,6 +171,10 @@ private slots:
 	void showAboutDialog();
 
 	void handleOutOfMemorySituation();
+
+    //Basic Multithread Support
+    void setMultithreaded(bool v_isMultithreaded);
+
 private:
 	class PageSelectionProviderImpl;
 	enum SavePromptResult { SAVE, DONT_SAVE, CANCEL };
@@ -302,6 +307,12 @@ private:
 	bool m_debug;
 	bool m_closing;
 	bool m_beepOnBatchProcessingCompletion;
+
+    // Multithread Support
+    int m_threadCount;
+    bool m_isMultithreaded;
+    bool isMultithreaded();
+    QList<WorkerThread*> m_WorkerThreads;
 };
 
 #endif

--- a/WorkerThread.cpp
+++ b/WorkerThread.cpp
@@ -117,6 +117,7 @@ WorkerThread::WorkerThread(QObject* parent)
 :	QObject(parent),
 	m_ptrImpl(new Impl(*this))
 {
+    m_isRunning = false;
 }
 
 WorkerThread::~WorkerThread()
@@ -134,6 +135,7 @@ WorkerThread::performTask(BackgroundTaskPtr const& task)
 {
 	if (m_ptrImpl.get()) {
 		m_ptrImpl->performTask(task);
+        m_isRunning = true;
 	}
 }
 
@@ -142,6 +144,12 @@ WorkerThread::emitTaskResult(
 	BackgroundTaskPtr const& task, FilterResultPtr const& result)
 {
 	emit taskResult(task, result);
+    m_isRunning = false;
+}
+
+bool WorkerThread::isRunning()
+{
+    return m_isRunning;
 }
 
 

--- a/WorkerThread.h
+++ b/WorkerThread.h
@@ -41,6 +41,9 @@ public:
 	 * useful to prematuraly stop task processing.
 	 */
 	void shutdown();
+
+    // Basic Multithread Support
+    bool isRunning();
 public slots:
 	void performTask(BackgroundTaskPtr const& task);
 signals:
@@ -54,6 +57,9 @@ private:
 	class TaskResultEvent;
 	
 	std::auto_ptr<Impl> m_ptrImpl;
+    //Basic Multithread Support
+    volatile bool m_isRunning;
+
 };
 
 #endif

--- a/ui/MainWindow.ui
+++ b/ui/MainWindow.ui
@@ -177,7 +177,7 @@
      <x>0</x>
      <y>0</y>
      <width>613</width>
-     <height>21</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuDebug">
@@ -188,6 +188,7 @@
     <addaction name="actionRelinking"/>
     <addaction name="separator"/>
     <addaction name="actionDebug"/>
+    <addaction name="actionEnable_Multithreading"/>
     <addaction name="separator"/>
     <addaction name="actionSettings"/>
    </widget>
@@ -353,6 +354,14 @@
   <action name="actionRelinking">
    <property name="text">
     <string>Relinking ...</string>
+   </property>
+  </action>
+  <action name="actionEnable_Multithreading">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable Multithreading</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
I created a small fix regarding feature request #42 to enable basic multi-threading support. By default, multi-threading is disabled and it can be enabled via the Tools->Enable Multithreading menu entry.

The structure is very simple, it creates WorkerThread instances according to the number of available threads/cores (minus 1) and distributes the batch tasks to them. The speed increase is quite noticeable, at least on modern multi-core machines.

I haven't worked much with Qt and C++, so if there are any issues with my code, please tell me.