### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/FileNameDisambiguator.cpp
+++ b/FileNameDisambiguator.cpp
@@ -246,7 +246,7 @@ FileNameDisambiguator::Impl::registerFile(QString const& file_path)
 	ItemsByFileNameLabel::iterator const fn_it(
 		m_itemsByFileNameLabel.upper_bound(boost::make_tuple(file_name))
 	);	
-	// If the item preceeding fn_it has the same file name,
+	// If the item preceding fn_it has the same file name,
 	// the new file belongs to the same disambiguation group.
 	if (fn_it != m_itemsByFileNameLabel.begin()) {
 		ItemsByFileNameLabel::iterator prev(fn_it);

--- a/ImageMetadataLoader.h
+++ b/ImageMetadataLoader.h
@@ -35,7 +35,7 @@ public:
 		LOADED, /**< Loaded successfully */
 		NO_IMAGES, /**< File contained no images. */
 		FORMAT_NOT_RECOGNIZED, /**< File format not recognized. */
-		GENERIC_ERROR /**< Some other error has occured. */
+		GENERIC_ERROR /**< Some other error has occurred. */
 	};
 	
 	/**

--- a/ImageTransformation.h
+++ b/ImageTransformation.h
@@ -95,7 +95,7 @@ public:
 	/**
 	 * \brief Get the target DPI for pre-scaling.
 	 *
-	 * Note that if the original DPI was assymetric, pre-scaling to
+	 * Note that if the original DPI was asymmetric, pre-scaling to
 	 * a symmetric DPI will be applied implicitly.
 	 */
 	Dpi const& preScaledDpi() const { return m_preScaledDpi; }

--- a/ImageViewBase.h
+++ b/ImageViewBase.h
@@ -173,7 +173,7 @@ public:
 	 * \brief Set the focal point in widget coordinates, after adjustring
 	 *        it to avoid wasting of widget space.
 	 *
-	 * This one may be used for resticted dragging (the default one in ST).
+	 * This one may be used for restricted dragging (the default one in ST).
 	 *
 	 * \see getWidgetFocalPoint()
 	 * \see setWidgetFocalPoint()

--- a/PageId.h
+++ b/PageId.h
@@ -38,7 +38,7 @@ public:
 	
 	/**
 	 * \note The default parameter for subpage is not arbitrary.  It has to
-	 *       preceed other values in terms of operator<().  That's necessary
+	 *       precede other values in terms of operator<().  That's necessary
 	 *       to be able to use lower_bound() to find the first page with
 	 *       a matching image id.
 	 */

--- a/RelinkingListView.cpp
+++ b/RelinkingListView.cpp
@@ -113,7 +113,7 @@ RelinkingListView::drawStatusLayer(QPainter* painter)
 	}
 
 	if (top_index.row() > 0) {
-		// The appearence of any element actually depends on its neighbours,
+		// The appearance of any element actually depends on its neighbours,
 		// so we start with the element above our topmost visible one.
 		top_index = top_index.sibling(top_index.row() - 1, 0);
 	}
@@ -136,7 +136,7 @@ RelinkingListView::drawStatusLayer(QPainter* painter)
 
 		if (row != top_index.row() && !item_rect.intersects(drawing_rect)) {
 			// Note that we intentionally break *after* processing
-			// the first invisible item. That's because the appearence
+			// the first invisible item. That's because the appearance
 			// of its immediate predecessor depends on it. The topmost item
 			// is allowed to be invisible, as it's processed for the same reason,
 			// that is to make its immediate neighbour to display correctly.

--- a/SmartFilenameOrdering.cpp
+++ b/SmartFilenameOrdering.cpp
@@ -77,6 +77,6 @@ SmartFilenameOrdering::operator()(QFileInfo const& lhs, QFileInfo const& rhs) co
 	
 	// OK, the smart comparison indicates the file names are equal.
 	// However, if they aren't symbol-to-symbol equal, we can't treat
-	// them as equal, so let's do a usual comparision now.
+	// them as equal, so let's do a usual comparison now.
 	return lhs_fname < rhs_fname;
 }

--- a/ThumbnailSequence.cpp
+++ b/ThumbnailSequence.cpp
@@ -1295,7 +1295,7 @@ ThumbnailSequence::Impl::itemInsertPosition(
 	ItemsInOrder::iterator ins_pos(hint);
 	int dist = 0;
 
-	// While the element immediately preceeding ins_pos is supposed to
+	// While the element immediately preceding ins_pos is supposed to
 	// follow the page we are inserting, move ins_pos one element back.
 	while (ins_pos != begin) {
 		ItemsInOrder::iterator prev(ins_pos);

--- a/ThumbnailSequence.h
+++ b/ThumbnailSequence.h
@@ -65,7 +65,7 @@ public:
 		 * selected items exist.  In this case, the leader will become unselected, and
 		 * one of the other selected items will be promoted to a selection leader.
 		 * In these circumstances, scrolling to make the new selection leader visible
-		 * is undesireable.
+		 * is undesirable.
 		 */
 		AVOID_SCROLLING_TO = 1 << 2
 	};
@@ -101,7 +101,7 @@ public:
 	PageSequence toPageSequence() const;
 
 	/**
-	 * \brief Updates appearence and possibly position of a thumbnail.
+	 * \brief Updates appearance and possibly position of a thumbnail.
 	 *
 	 * If thumbnail's size or position have changed and this thumbnail
 	 * is a selection leader, newSelectionLeader() signal will be emitted
@@ -122,7 +122,7 @@ public:
 	void invalidateThumbnail(PageInfo const& page_info);
 	
 	/**
-	 * \brief Updates appearence of all thumbnails and possibly their order.
+	 * \brief Updates appearance of all thumbnails and possibly their order.
 	 *
 	 * Whether or not order will be updated depends on whether an order provider
 	 * was specified by the most recent reset() call.
@@ -152,7 +152,7 @@ public:
 	 * \brief Returns the page immediately following the given one.
 	 *
 	 * A null PageInfo is returned if the given page wasn't found or
-	 * there are no pages preceeding it.
+	 * there are no pages preceding it.
 	 */
 	PageInfo prevPage(PageId const& reference_page) const;
 

--- a/compat/pstdint.h
+++ b/compat/pstdint.h
@@ -74,7 +74,7 @@
  *       include stdint.h.  The hope is that one or the other can be
  *       used with no real difference.
  *
- *    5) In the current verison, if your platform can't represent
+ *    5) In the current version, if your platform can't represent
  *       int32_t, int16_t and int8_t, it just dumps out with a compiler
  *       error.
  *

--- a/crash_reporter/google-breakpad/google_breakpad/common/minidump_exception_solaris.h
+++ b/crash_reporter/google-breakpad/google_breakpad/common/minidump_exception_solaris.h
@@ -69,7 +69,7 @@ typedef enum {
   MD_EXCEPTION_CODE_SOL_SIGPWR = 19,     /* power-fail restart */
   MD_EXCEPTION_CODE_SOL_SIGWINCH = 20,   /* window size change */
   MD_EXCEPTION_CODE_SOL_SIGURG = 21,     /* urgent socket condition */
-  MD_EXCEPTION_CODE_SOL_SIGPOLL = 22,    /* pollable event occured */
+  MD_EXCEPTION_CODE_SOL_SIGPOLL = 22,    /* pollable event occurred */
   MD_EXCEPTION_CODE_SOL_SIGIO = 22,      /* socket I/O possible (SIGPOLL alias) */
   MD_EXCEPTION_CODE_SOL_SIGSTOP = 23,    /* stop (cannot be caught or ignored) */
   MD_EXCEPTION_CODE_SOL_SIGTSTP = 24,    /* user stop requested from tty */

--- a/filters/page_split/ImageView.h
+++ b/filters/page_split/ImageView.h
@@ -106,7 +106,7 @@ private:
 
 	/**
 	 * Same as ImageViewBase::getVisibleWidgetRect(), except reduced
-	 * vertically to accomodate the height of line endpoint handles.
+	 * vertically to accommodate the height of line endpoint handles.
 	 */
 	QRectF reducedWidgetArea() const;
 

--- a/filters/page_split/PageLayoutEstimator.cpp
+++ b/filters/page_split/PageLayoutEstimator.cpp
@@ -101,7 +101,7 @@ struct CenterComparator
  * \param layout_type The requested layout type.  The layout type of
  *        SINGLE_PAGE_UNCUT is not handled here.
  * \param ltr_lines Folding line candidates sorted from left to right.
- * \param image_size The dimentions of the page image.
+ * \param image_size The dimensions of the page image.
  * \param hor_shadows A downscaled grayscale image that contains
  *        long enough and not too thin horizontal lines.
  * \param dbg An optional sink for debugging images.
@@ -180,7 +180,7 @@ std::auto_ptr<PageLayout> autoDetectSinglePageLayout(
  * \brief Try to auto-detect a page layout for a two-page configuration.
  *
  * \param ltr_lines Folding line candidates sorted from left to right.
- * \param image_size The dimentions of the page image.
+ * \param image_size The dimensions of the page image.
  * \return The page layout detected or a null auto_ptr.
  */
 std::auto_ptr<PageLayout> autoDetectTwoPageLayout(

--- a/filters/select_content/ContentBoxFinder.cpp
+++ b/filters/select_content/ContentBoxFinder.cpp
@@ -1399,7 +1399,7 @@ ContentBoxFinder::filterShadows(
 	
 	status.throwIfCancelled();
 	
-	// Long white vertical lines are definately not spaces between letters.
+	// Long white vertical lines are definitely not spaces between letters.
 	BinaryImage vert_whitespace(
 		closeBrick(reduced_dithering, QSize(1, 150), BLACK)
 	);

--- a/filters/select_content/Task.cpp
+++ b/filters/select_content/Task.cpp
@@ -114,7 +114,7 @@ Task::process(TaskStatus const& status, FilterData const& data)
 		}
 
 		if ((params->contentSizeMM().isEmpty() && !params->contentRect().isEmpty()) || !params->dependencies().matches(deps)) {
-			// Backwards compatibilty: put the missing data where it belongs.
+			// Backwards compatibility: put the missing data where it belongs.
 			Params const new_params(
 				ui_data.contentRect(), ui_data.contentSizeMM(),
 				deps, params->mode()

--- a/foundation/PriorityQueue.h
+++ b/foundation/PriorityQueue.h
@@ -67,7 +67,7 @@ public:
 
 	/**
 	 * Like push(), but implemented through swapping \p obj with a default
-	 * constructed instance of T. This will make sence if copying a default
+	 * constructed instance of T. This will make sense if copying a default
 	 * constructed instance of T is much cheaper than copying \p obj.
 	 */
 	void pushDestructive(T& obj);

--- a/imageproc/FindPeaksGeneric.h
+++ b/imageproc/FindPeaksGeneric.h
@@ -92,7 +92,7 @@ void raiseAllButPeaks(
  * \param most_significant A functor or a pointer to a free function that
  *        can be called with two arguments of type T and return the bigger
  *        or the smaller of the two.
- * \param least_significant Same as most_significant, but the oposite operation.
+ * \param least_significant Same as most_significant, but the opposite operation.
  * \param increase_significance A functor or a pointer to a free function that
  *        takes one argument and returns the next most significant value next
  *        to it.  Hint: for floating point data, use the nextafter() family of

--- a/imageproc/MaxWhitespaceFinder.cpp
+++ b/imageproc/MaxWhitespaceFinder.cpp
@@ -260,7 +260,7 @@ MaxWhitespaceFinder::findBlackPixelCloseToCenter(
 			// This means we are dealing with a horizontal line
 			// and that we only have to check at most two pixels
 			// (the endpoints) and that at least one of them
-			// is definately black and that rect is a 1x1 pixels
+			// is definitely black and that rect is a 1x1 pixels
 			// block pointing to the left endpoint.
 			if (sum != 0) {
 				return outer_rect.topLeft();

--- a/imageproc/MaxWhitespaceFinder.h
+++ b/imageproc/MaxWhitespaceFinder.h
@@ -327,7 +327,7 @@ PriorityStorageImpl<QualityCompare>::popHeap(
 	
 	// Now raise the node until it's at correct position.  Very little
 	// raising should be necessary, that's why it's faster than adding
-	// an additional comparision to the loop where we lower the node.
+	// an additional comparison to the loop where we lower the node.
 	pushHeap(begin, begin + nodeIdx + 1);
 }
 

--- a/imageproc/Morphology.cpp
+++ b/imageproc/Morphology.cpp
@@ -707,7 +707,7 @@ GrayImage dilateOrErodeGray(
 	}
 	CoordinateSystem const dst_cs(dst_area.topLeft());
 	
-	// Each pixel will be a minumum or maximum of a group of pixels
+	// Each pixel will be a minimum or maximum of a group of pixels
 	// in its neighborhood.  The neighborhood is defined by collect_area.
 	Brick const collect_area(brick.flipped());
 	

--- a/imageproc/PolynomialSurface.h
+++ b/imageproc/PolynomialSurface.h
@@ -81,7 +81,7 @@ public:
 	/**
 	 * \brief Visualizes the polynomial surface as a grayscale image.
 	 *
-	 * The surface will be stretched / shrinked to fit the new size.
+	 * The surface will be stretched / shrunk to fit the new size.
 	 */
 	GrayImage render(QSize const& size) const;
 private:

--- a/imageproc/SeedFillGeneric.h
+++ b/imageproc/SeedFillGeneric.h
@@ -510,7 +510,7 @@ void seedFill8(
  *
  * \param spread_op A functor or a pointer to a free function that can be called with
  *        two arguments of type T and return the bigger or the smaller of the two.
- * \param mask_op Same as spread_op, but the oposite operation.
+ * \param mask_op Same as spread_op, but the opposite operation.
  * \param conn Determines whether to spread values to 4 or 8 eight immediate neighbors.
  * \param[in,out] seed Pointer to the seed buffer.
  * \param seed_stride The size of a row in the seed buffer, in terms of the number of T objects.

--- a/math/spfit/FrenetFrame.h
+++ b/math/spfit/FrenetFrame.h
@@ -36,7 +36,7 @@ public:
 	/**
 	 * \brief Builds a Frenet frame from an origin and a (non-unit) tangent vector.
 	 *
-	 * The direction of the normal vector is choosen according to \p ydir,
+	 * The direction of the normal vector is chosen according to \p ydir,
 	 * considering the tangent vector to be pointing to the right.  The normal direction
 	 * does matter, as we want the unit normal vector divided by signed curvature give
 	 * us the center of the curvature.  For that to be the case, normal vector's direction

--- a/packaging/windows/readme.en.txt
+++ b/packaging/windows/readme.en.txt
@@ -181,7 +181,7 @@ latest stable version.
    Select your version of Visual C++ (Visual Studio) instead of "MinGW Makefiles"
 
 9. Now we are going to build Scan Tailor itself.  On subsequent build of the
-   same (possiblity modified) version, you can start right from this step.
+   same (possibly modified) version, you can start right from this step.
    For building a different version, start from step 8.
    
    [VC++]


### PR DESCRIPTION
All of them were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>