### PR TITLE
Tiff compression may be changed in settings file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,6 +511,7 @@ SET(
 	PageRange.cpp PageRange.h
 	SelectedPage.cpp SelectedPage.h
 	Utils.cpp Utils.h
+        SettingsDefaults.h
 	PageView.h
 	AutoManualMode.h
 	AbstractCommand.h

--- a/SettingsDefaults.h
+++ b/SettingsDefaults.h
@@ -1,0 +1,84 @@
+/*
+    Scan Tailor - Interactive post-processing tool for scanned pages.
+    Copyright (C) 2007-2009  Joseph Artsimovich <joseph_a@mail.ru>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SETTINGS_DEFAULTS_H_
+#define SETTINGS_DEFAULTS_H_
+
+#include <QSettings>
+#include <QVector>
+
+/*
+ * These are helper classes that let easily register a callback function
+ * in any .cpp file that will be called at application start.
+ * The function is expected to write default settings hints to QSettings
+ * as QSettings strips out commentaries.
+ *
+ * Callback function prototype receives bool argument that indicates cases
+ * of GUI and console applications. It returns true if everything is fine
+ *
+ * To register a callback one shall include this header file
+ * and create static instance of RegisterSettingsDefaults class passing
+ * pointer to a callback in its constructor.
+ *
+ */
+
+// Callback function prototype
+typedef bool (*funcSettingsDefaults)(bool);
+
+// Static class that collects pointers to all callback functions
+
+class SettingsDefaults
+{
+public:
+    static bool registerSettingsFunc(funcSettingsDefaults funcCallback, bool isGUI = true)
+    {
+        // local static variable behaves like global
+        static QVector<funcSettingsDefaults> knownFuncs;
+
+        // funcCallback is always null if function called from main
+        // and must be non null if called from other cpp modules
+        // isGUI value is meaningful only in first case.
+
+        if (funcCallback != NULL) {
+            knownFuncs.append(funcCallback);
+        } else {
+            foreach (funcSettingsDefaults func, knownFuncs) {
+                if (!func(isGUI)) return false;
+            }
+        }
+        return true;
+    }
+
+    // wrapper function that interfaces application main()
+    static bool prepareDefaults(bool isGUI)
+    {
+        return registerSettingsFunc(nullptr, isGUI);
+    }
+
+};
+
+// helper class that allows to call a static function at cpp module load time
+
+class RegisterSettingsDefaults
+{
+public:
+    RegisterSettingsDefaults(funcSettingsDefaults funcCallback)  { SettingsDefaults::registerSettingsFunc(funcCallback); }
+};
+
+
+#endif

--- a/main-cli.cpp
+++ b/main-cli.cpp
@@ -25,6 +25,7 @@
 
 #include "CommandLine.h"
 #include "ConsoleBatch.h"
+#include "SettingsDefaults.h"
 
 
 int main(int argc, char **argv)
@@ -35,6 +36,7 @@ int main(int argc, char **argv)
     app.setOrganizationName("Scan Tailor");
     app.setOrganizationDomain("scantailor.sourceforge.net");
     QSettings::setDefaultFormat(QSettings::IniFormat);
+    SettingsDefaults::prepareDefaults(false);
 
 #ifdef _WIN32
 	// Get rid of all references to Qt's installation directory.

--- a/main-cli.cpp
+++ b/main-cli.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <QCoreApplication>
+#include <QSettings>
 #include <QString>
 #include <QStringList>
 #include <iostream>
@@ -29,6 +30,11 @@
 int main(int argc, char **argv)
 {
 	QCoreApplication app(argc, argv);
+    // This information is used by QSettings.
+    app.setApplicationName("Scan Tailor");
+    app.setOrganizationName("Scan Tailor");
+    app.setOrganizationDomain("scantailor.sourceforge.net");
+    QSettings::setDefaultFormat(QSettings::IniFormat);
 
 #ifdef _WIN32
 	// Get rid of all references to Qt's installation directory.

--- a/main.cpp
+++ b/main.cpp
@@ -22,6 +22,7 @@
 #include "PngMetadataLoader.h"
 #include "TiffMetadataLoader.h"
 #include "JpegMetadataLoader.h"
+#include "SettingsDefaults.h"
 #include <QMetaType>
 #include <QtPlugin>
 #include <QLocale>
@@ -179,6 +180,7 @@ int main(int argc, char** argv)
 	app.setOrganizationName("Scan Tailor");
 	app.setOrganizationDomain("scantailor.sourceforge.net");
 	QSettings::setDefaultFormat(QSettings::IniFormat);
+    SettingsDefaults::prepareDefaults(true);
 	QSettings settings;
 	
 	PngMetadataLoader::registerMyself();

--- a/main.cpp
+++ b/main.cpp
@@ -178,6 +178,7 @@ int main(int argc, char** argv)
 	app.setApplicationName("Scan Tailor");
 	app.setOrganizationName("Scan Tailor");
 	app.setOrganizationDomain("scantailor.sourceforge.net");
+	QSettings::setDefaultFormat(QSettings::IniFormat);
 	QSettings settings;
 	
 	PngMetadataLoader::registerMyself();


### PR DESCRIPTION
This PR addresses #201 and demonstrates settings file usage.
It contains 3 commits:
1. Enforcing settings storage as ini file among platforms. Which is also submitted standalone in #266 
2. Fancy static helper class that allows easily call callback function at application start to make sure settings file contains hints. As Qt settings file implementation strip outs comments.
3. Tiff compression change implementation based on settings file. 2 commits above allows to implement it with only changing one tiff cpp module.

As for setting itself, you'll find following lines in Scan Tailor.ini:
```
[tiff]
compressionMethod-hint="Tiff compression method may take following values: NONE, CCITTRLE, CCITTFAX3, CCITT_T4, CCITTFAX4, CCITT_T6, LZW, OJPEG, JPEG, T85, T43, NEXT, CCITTRLEW, PACKBITS, THUNDERSCAN, IT8CTPAD, IT8LW, IT8MP, IT8BL, PIXARFILM, PIXARLOG, DEFLATE, ADOBE_DEFLATE, DCS, JBIG, SGILOG, SGILOG24, JP2000, LZMA. Default value: LZW. Note: not all methods may be implemented by libtiff. The error messages are printed to console."
compressionMethod=LZW
```

I've tried some values - NONE and DEFLATE works. Several, like JP2000, wasn't implemented in my system. JPEG complains on incompatible image settings set up. The error messages are shown in console. Scan Tailor's GUI show no error dialogs in case of problems - just stops doing anything without refreshing page thumbnail image.