### PR TITLE
Update TextLineTracer.cpp

### DIFF
--- a/dewarping/TextLineTracer.cpp
+++ b/dewarping/TextLineTracer.cpp
@@ -247,7 +247,7 @@ TextLineTracer::isCurvatureConsistent(std::vector<QPointF> const& polyline)
 		prev_normal_sqlen = next_segment_sqlen;
 	}
 
-	return !(significant_positive && significant_positive);
+	return !(significant_negative && significant_positive);
 }
 
 bool


### PR DESCRIPTION
A small bug caught by a static code analyzer.
Otherwise `TextLineTracer::isCurvatureConsistent` is always return false.

Tulon have [merged this fix](https://github.com/Tulon/scantailor/pull/5) in his fork, so it must be a bug.