### PR TITLE
Fix dewarped binary output colorspace format

### DIFF
--- a/filters/output/OutputGenerator.cpp
+++ b/filters/output/OutputGenerator.cpp
@@ -1682,7 +1682,7 @@ OutputGenerator::processWithDewarping(
 //begin of modified by monday2000
 		QImage tmp_image(dewarped_bw_content.toQImage()); 
 		maybe_deskew(&tmp_image, dewarping_mode);		
-		return tmp_image;		
+		return tmp_image.convertToFormat(QImage::Format_Mono);		
 //end of modified by monday2000
 	}
 


### PR DESCRIPTION
After dewarp additional deskew may be applied. In case of binary output that will change image colorspace format from mono to indexed8. As a result output filesize will increase significantly.
The problems is that imageproc::transform() doesn't support binary colorspace and convert image to rgb while BinaryImage::toQImage() always return QImage in Format_Mono.
I don't want to add mono format support into imageproc::transform() so just enforce conversion back to mono format for such output.