### PR TITLE
Bugfix

### DIFF
--- a/ThumbnailBase.cpp
+++ b/ThumbnailBase.cpp
@@ -149,7 +149,7 @@ ThumbnailBase::paint(QPainter* painter,
 	QString const cache_key(QString::fromAscii("ThumbnailBase::temp_pixmap"));
 	if (!QPixmapCache::find(cache_key, temp_pixmap)
 			|| temp_pixmap.width() < display_rect.width()
-			|| temp_pixmap.height() < display_rect.width()) {
+			|| temp_pixmap.height() < display_rect.height()) {
 		int w = (int)display_rect.width();
 		int h = (int)display_rect.height();
 		


### PR DESCRIPTION
Here's a small bug. In case you have two thumbnails scaled to 90x200 (height x width) and 200x100 the second thumbnail might be drown as ~ 100x100 (bottom part clipped) as temp_pixmap won't be resized to match bigger height.