### PR TITLE
Enable options to be passed from command line

### DIFF
--- a/CommandLine.h
+++ b/CommandLine.h
@@ -55,6 +55,7 @@ public:
 		m_dewarpingMode = fetchDewarpingMode();    
 		m_despeckleLevel = fetchDespeckleLevel();
 		m_deskewAngle = fetchDeskewAngle();
+		m_threshold = fetchThreshold();
 	}
 
 	bool isGui() const { return m_gui; }

--- a/CommandLine.h
+++ b/CommandLine.h
@@ -50,7 +50,12 @@ public:
 	static CommandLine const& get() { return m_globalInstance; }
 	static void set(CommandLine const& cl);
 
-	CommandLine(QStringList const& argv, bool g=true) : m_gui(g), m_global(false) { CommandLine::parseCli(argv); }
+	CommandLine(QStringList const& argv, bool g=true) : m_gui(g), m_global(false) { 
+		CommandLine::parseCli(argv); 
+		m_dewarpingMode = fetchDewarpingMode();    
+		m_despeckleLevel = fetchDespeckleLevel();
+		m_deskewAngle = fetchDeskewAngle();
+	}
 
 	bool isGui() const { return m_gui; }
 	bool isVerbose() const { return contains("verbose"); }


### PR DESCRIPTION
When we use some some options from command line, they were not passed to the engine.