### PR TITLE
Fix detection of second chance components

### DIFF
--- a/Despeckle.cpp
+++ b/Despeckle.cpp
@@ -824,7 +824,10 @@ Despeckle::despeckleInPlace(
 	
 	bool have_anchored_to_small_but_not_big = false;
 	BOOST_FOREACH(Component const& comp, components) {
-		have_anchored_to_small_but_not_big = comp.anchoredToSmallButNotBig();
+		if (comp.anchoredToSmallButNotBig()) {
+			have_anchored_to_small_but_not_big = true;
+			break;
+		}
 	}
 	
 	if (have_anchored_to_small_but_not_big) {


### PR DESCRIPTION
That seems to be a bug. I've tested and found that there are pages when `have_anchored_to_small_but_not_big` got true but then was reset to false. After the proposed fix the despeckle results are more accurate:
![3](https://user-images.githubusercontent.com/5746456/61072694-7cb83f80-a41c-11e9-9cc6-1a4e0650503e.png)
