### PR TITLE
fixed incorrect link for "Heroes and Cobblestones"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Scan Tailor is being used not just by enthusiasts, but also by libraries and oth
     done with Scan Tailor, but all of the scanned image cleanup was. [[1](scantailor.org/downloads/)]
   - [Oakland Township: Two Hundred Years](http://books.google.com/books?printsec=frontcover&id=o4Q2OlVl61MC) 
       by Stuart A. Rammage (also available: volumes 2, 3, 4.1, 4.2, 5.1, and 5.2) [[2](http://www.diybookscanner.org/forum/viewtopic.php?t=435)]
-  - [Herons and Cobblestones](http://books.google.com/books?printsec=frontcover&id=o4Q2OlVl61MC): A History of Bethel and the Five Oaks Area of Brantford Township, 
+  - [Herons and Cobblestones](http://books.google.com.ng/books?printsec=frontcover&id=sQj6XPKB6ZAC): A History of Bethel and the Five Oaks Area of Brantford Township, 
       County of Brant by the Grand River Heritage Mines Society [[2](http://www.diybookscanner.org/forum/viewtopic.php?t=435)]
 
 


### PR DESCRIPTION
Corrected the link to the book "Heroes and Cobblestones". The initial link "http://books.google.com/books?printsec=frontcover&id=o4Q2OlVl61MC" was erroneously pointing to "Oakland Township: Two Hundred Years". The correct link is "http://books.google.com.ng/books?printsec=frontcover&id=sQj6XPKB6ZAC". You can check it out :)