### PR TITLE
Remove uneccessary call to toGrayscale

### DIFF
--- a/imageproc/Grayscale.cpp
+++ b/imageproc/Grayscale.cpp
@@ -275,15 +275,14 @@ GrayImage createFramedImage(QSize const& size,
 	return image;
 }
 
-unsigned char darkestGrayLevel(QImage const& image)
+unsigned char darkestGrayLevel(GrayImage const& image)
 {
-	QImage const gray(toGrayscale(image));
 	
 	int const width = image.width();
 	int const height = image.height();
 	
-	unsigned char const* line = image.bits();
-	int const bpl = image.bytesPerLine();
+	unsigned char const* line = image.toQImage().bits();
+	int const bpl = image.toQImage().bytesPerLine();
 	
 	unsigned char darkest = 0xff;
 	

--- a/imageproc/Grayscale.h
+++ b/imageproc/Grayscale.h
@@ -100,11 +100,10 @@ GrayImage createFramedImage(
 /**
  * \brief Find the darkest gray level of an image.
  *
- * \param image The image to process.  If it's null, 0xff will
- *        be returned as the darkest image.  If it's not grayscale,
- *        a grayscale copy will be created.
+ * \param image The GrayImage to process.  If it's null, 0xff will
+ *        be returned as the darkest image.
  */
-unsigned char darkestGrayLevel(QImage const& image);
+unsigned char darkestGrayLevel(const GrayImage &image);
 
 } // namespace imageproc
 


### PR DESCRIPTION
Remove uneccessary call to toGrayscale as darkestGrayLevel() is always used with GrayImage as argument. So no need to create QImage. Just making sure GrayImage is passed to darkestGrayLevel() by changing type of argument in function declaration.